### PR TITLE
repo: set a default in the case statement so tests pass

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -17,7 +17,7 @@ class elasticsearch::repo (
 ) {
 
   case $version {
-    '0.90': {
+    default: {
       $repo_url       = 'https://packages.elastic.co/elasticsearch/0.90/debian'
       $allow_unsigned = true
     }


### PR DESCRIPTION
Although we use an `Enum` for the variable type, so shouldn't get anything unexpected, this is good style and its absence is causing a test failure. Given `0.90` is currently the default we'll use this as the fallback for now.