### PR TITLE
Repo: add a paramater to make APT repo optional

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,5 @@
 ---
+elasticsearch::manage_repo: true
 elasticsearch::version: '0.90'
 elasticsearch::cluster_name: elasticsearch
 elasticsearch::node_name: "%{facts.networking.hostname}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,9 @@
 #
 # This module installs and manages Elasticsearch in a very simple manner.
 #
+# @param manage_repo
+#    Whether to manage the APT repository or not
+#
 # @param version
 #    Version to install
 #
@@ -34,6 +37,7 @@
 #   class { 'elasticsearch': }
 #
 class elasticsearch (
+  Boolean $manage_repo,
   Enum['0.90', '1'] $version,
   String $cluster_name,
   String $node_name,
@@ -45,14 +49,26 @@ class elasticsearch (
   Integer $number_of_replicas,
 ) {
 
-  class { 'elasticsearch::repo': }
-  -> class { 'elasticsearch::install': }
-  -> class { 'elasticsearch::config': }
-  ~> class { 'elasticsearch::service': }
+  if $manage_repo {
+    class { 'elasticsearch::repo': }
+    -> class { 'elasticsearch::install': }
+    -> class { 'elasticsearch::config': }
+    ~> class { 'elasticsearch::service': }
 
-  contain elasticsearch::repo
-  contain elasticsearch::install
-  contain elasticsearch::config
-  contain elasticsearch::service
+    contain elasticsearch::repo
+    contain elasticsearch::install
+    contain elasticsearch::config
+    contain elasticsearch::service
+  }
+
+  else {
+    class { 'elasticsearch::install': }
+    -> class { 'elasticsearch::config': }
+    ~> class { 'elasticsearch::service': }
+
+    contain elasticsearch::install
+    contain elasticsearch::config
+    contain elasticsearch::service
+  }
 
 }

--- a/spec/classes/elasticsearch_spec.rb
+++ b/spec/classes/elasticsearch_spec.rb
@@ -5,12 +5,25 @@ describe 'elasticsearch' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it do
-        is_expected.to compile
-        is_expected.to contain_class('elasticsearch::repo')
-        is_expected.to contain_class('elasticsearch::install')
-        is_expected.to contain_class('elasticsearch::config')
-        is_expected.to contain_class('elasticsearch::service')
+      context 'with defaults' do
+        it do
+          is_expected.to compile
+          is_expected.to contain_class('elasticsearch::repo')
+          is_expected.to contain_class('elasticsearch::install')
+          is_expected.to contain_class('elasticsearch::config')
+          is_expected.to contain_class('elasticsearch::service')
+        end
+      end
+      context 'with manage_repo => false' do
+        let(:pre_condition) { 'class { "elasticsearch": manage_repo => false }' }
+
+        it do
+          is_expected.to compile
+          is_expected.not_to contain_class('elasticsearch::repo')
+          is_expected.to contain_class('elasticsearch::install')
+          is_expected.to contain_class('elasticsearch::config')
+          is_expected.to contain_class('elasticsearch::service')
+        end
       end
     end
   end


### PR DESCRIPTION
There may be use cases where this needs to be removed or handled separately.