### PR TITLE
install: add a `package_ensure` param to control installation

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -7,5 +7,6 @@ elasticsearch::heap_size: '2g'
 elasticsearch::max_locked_memory: 'unlimited'
 elasticsearch::bootstrap_mlockall: 'true'
 elasticsearch::http_max_content_length: 512mb
+elasticsearch::package_ensure: installed
 elasticsearch::number_of_shards: 1
 elasticsearch::number_of_replicas: 0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,9 @@
 # @param http_max_content_length
 #    Set max content length for HTTP traffic
 #
+# @param package_ensure
+#    Value of the `ensure` parameter for the package resource
+#
 # @param number_of_shards
 #    How many shards
 #
@@ -45,6 +48,7 @@ class elasticsearch (
   String $max_locked_memory,
   String $bootstrap_mlockall,
   String $http_max_content_length,
+  String $package_ensure,
   Integer $number_of_shards,
   Integer $number_of_replicas,
 ) {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,10 +6,12 @@
 # @example
 #   include elasticsearch::install
 #
-class elasticsearch::install {
+class elasticsearch::install (
+  String $package_ensure = $elasticsearch::package_ensure,
+) {
 
   package { 'elasticsearch':
-    ensure => 'installed',
+    ensure => $package_ensure,
   }
 
 }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -5,9 +5,22 @@ describe 'elasticsearch::install' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it do
-        is_expected.to compile
-        is_expected.to contain_package('elasticsearch').with('ensure' => 'installed')
+      context 'with defaults' do
+        let(:pre_condition) { 'include elasticsearch' }
+
+        it do
+          is_expected.to compile
+          is_expected.to contain_package('elasticsearch').with('ensure' => 'installed')
+        end
+      end
+
+      context 'with ensure => 0.90.13' do
+        let(:pre_condition) { 'class { "elasticsearch": package_ensure => "0.90.13" }' }
+
+        it do
+          is_expected.to compile
+          is_expected.to contain_package('elasticsearch').with('ensure' => '0.90.13')
+        end
       end
     end
   end


### PR DESCRIPTION
This adds a paramter, `package_ensure`, to the install class that permits control over the `ensure` parameter of the contained `package` resource, thus allowing more fine-grained control.